### PR TITLE
Added Starfish Test environment support to Java CoAP Client

### DIFF
--- a/SDK/Java CoAP Client/README.md
+++ b/SDK/Java CoAP Client/README.md
@@ -140,11 +140,12 @@ All command line configuration options are described in this section.
 | proxyPort | The port number of the CoAP proxy.
 | clientPort | The UDP listening port used by the client. Default is 6000.
 | method | The CoAP method. Default is GET.
-| observe| Used in conjunction with the GET method. Set to true to establish an observe on a CoAP resource. Default is false.
+| observe| Used in conjunction with the GET method. Include to establish an observe on a CoAP resource. Default is false.
 | maxNotifications | Sets a limit on how many observe notifications are read by the client. Default is 1. Note that after the client shuts down after maxNotifications have been received, the CoAP resources observe is not cancelled.
 | timeout | The time in seconds allowed for a response from a CoAP activity. If an observe has been established the client will shutdown on the timeout even if maxNotifications have not been received. It is up to the user to set the timeout value accordingly. Default is 60 seconds.
 | clientId | Your Starfish account client id.
 | clientSecret | Your Starfish account client secret.
+| test | Include this option to use the Starfish Test environment.
 
 **Note**: If no proxy is used, the proxyHost and proxyPort options must not be present in the
 configuration.

--- a/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/SdkCoapClient.java
+++ b/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/SdkCoapClient.java
@@ -62,17 +62,56 @@ public class SdkCoapClient extends CoapClient
             messageCode= MessageCode.PUT;
         }
 
-        // determine the URI of the resource to be requested
+        // Get URI of the resource to be requested
         String host = arguments.getDeviceHost();
         int port = arguments.getDevicePort();
         String path = arguments.getDevicePath();
         String query = arguments.getDeviceQuery();
         URI resourceURI = new URI("coap", null, host, port, path, query, null);
 
-        // create the request
-        boolean useProxy = arguments.getProxyAddress() != null;
+        // Confirmable
         int messageType = arguments.isNon() ? MessageType.NON : MessageType.CON;
-        CoapRequest coapRequest = new CoapRequest(messageType, messageCode, resourceURI, useProxy);
+
+        // Set the client callback
+        if (arguments.isObserve()) {
+            callback = new SdkObservationCallback(arguments);
+        } else {
+            callback = new SdkCallback();
+        }
+
+        boolean useProxy = arguments.getProxyAddress() != null;
+
+        // If it's a session call. SSNI gateway specific security code - get a session.
+        CoapRequest coapRequest = null;
+        if (messageCode == MessageCode.POST || messageCode == MessageCode.PUT)
+        {
+            if (path.equals("/sessions") && (arguments.getClientId() != null && arguments.getClientId().length() > 0))
+            {
+                TokenClient tc = new TokenClient(arguments.isTestEnv());
+                String token;
+                try
+                {
+                    token = tc.getApiToken(arguments.getClientId(), arguments.getClientSecret());
+                }
+                catch (Exception excpn)
+                {
+                    log.error("Aborting: Failed to acquire API token: {}", excpn.getMessage());
+                    return;
+                }
+                byte[] payload = token.getBytes();
+                if (useProxy)
+                {
+                    useProxy = false;
+                }
+                coapRequest = new CoapRequest(messageType, messageCode, resourceURI, useProxy);
+                coapRequest.setContent(payload, ContentFormat.TEXT_PLAIN_UTF8);
+            }
+        }
+        else
+        {
+            coapRequest = new CoapRequest(messageType, messageCode, resourceURI, useProxy);
+        }
+
 
         if (messageCode == MessageCode.GET)
         {
@@ -86,27 +125,6 @@ public class SdkCoapClient extends CoapClient
             coapRequest.setObserve(0);
         }
 
-        // If it's a session call
-        // TODO: Generalize
-        if (messageCode == MessageCode.POST || messageCode == MessageCode.PUT)
-        {
-            if (path.equals("/sessions") && (arguments.getClientId() != null && arguments.getClientId().length() > 0))
-            {
-                TokenClient tc = new TokenClient();
-                String token;
-                try
-                {
-                    token = tc.getApiToken(arguments.getClientId(), arguments.getClientSecret());
-                } catch (Exception excpn)
-                {
-                    log.error("Aborting: Failed to acquire API token: {}", excpn.getMessage());
-                    return;
-                }
-                byte[] payload = token.getBytes();
-                coapRequest.setContent(payload, ContentFormat.TEXT_PLAIN_UTF8);
-            }
-        }
-
         // determine recipient (proxy or CoAP resource host)
         InetSocketAddress remoteSocket;
         if (useProxy) {
@@ -117,13 +135,6 @@ public class SdkCoapClient extends CoapClient
             InetAddress serverAddress = InetAddress.getByName(arguments.getDeviceHost());
             int serverPort = arguments.getDevicePort();
             remoteSocket = new InetSocketAddress(serverAddress, serverPort);
-        }
-
-        // define the client callback
-        if (arguments.isObserve()) {
-            callback = new SdkObservationCallback(arguments);
-        } else {
-            callback = new SdkCallback();
         }
 
         //Send the CoAP request

--- a/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/StarfishClient.java
+++ b/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/StarfishClient.java
@@ -6,10 +6,8 @@ package com.ssn.sdk.coapclient;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLPeerUnverifiedException;
-import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URL;
 import java.security.cert.Certificate;
 import java.text.SimpleDateFormat;
@@ -27,30 +25,45 @@ public class StarfishClient
 {
     private Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-    private static String observationsUrl = "https://api.data-platform.developer.ssni.com/api/solutions/sandbox/devices";
+    // Starfish Staging and Production environment observations endpoint
+    private static final String stagingObservationsEndpoint = "https://api.data-platform.developer.ssni.com/api/solutions/sandbox/devices";
 
+    // Starfish Test environment observations endpoint
+    private static final String testObservationsEndpoint = "https://poc.api.dev.ssniot.cloud/api/solutions/sandbox/devices";
 
-    // Dev Specific
+    // Default observations URL
+    private static String observationsUrl = stagingObservationsEndpoint;
+
+    // Class specific
     private static String clientId = null;
     private static String clientSecret = null;
-    //private static String apiToken = null;
+    private static String deviceId = null;
+    private static boolean useTestEnvironment = false;
 
 
     /**
-     *  Initializes an instance of {@link SdkCoapObserver}.
+     *  Initializes an instance of {@link StarfishClient}.
      *
      */
-    public StarfishClient(String sfClientId, String sfClientSecret )
+    public StarfishClient(String sfClientId, String sfClientSecret, String sfDeviceId, boolean sfUseTestEnvironment )
     {
         clientId = sfClientId;
         clientSecret = sfClientSecret;
+        deviceId = sfDeviceId;
+        useTestEnvironment = sfUseTestEnvironment;
+
+        // Set test observations endpoint if using the test environment
+        if (sfUseTestEnvironment)
+        {
+            observationsUrl = testObservationsEndpoint;
+        }
     }
 
 
-    public void sendObservation(String observation, String deviceId)
+    public void sendObservation(String observation)
     {
         // Get token
-        TokenClient tc = new TokenClient();
+        TokenClient tc = new TokenClient(useTestEnvironment);
         String token;
         try
         {

--- a/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/TokenClient.java
+++ b/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/TokenClient.java
@@ -22,14 +22,35 @@ public class TokenClient
 {
     private Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-    // Starfish token endpoint
-    private static final String tokenUrl = "https://api.data-platform.developer.ssni.com/api/tokens";
+    // Starfish Staging and Production enviornment tokens endpoint
+    private static final String stagingTokensEndpoint = "https://api.data-platform.developer.ssni.com/api/tokens";
+
+    // Starfish Test enviornment tokens endpoint
+    private static final String testTokensEndpoint = "https://poc.api.ssniot.cloud/api/tokens";
+
+    // Default tokenUrl
+    private static String tokenUrl = stagingTokensEndpoint;
+
+
+    /**
+     *  Initializes an instance of {@link TokenClient}.
+     *
+     */
+    public TokenClient(boolean useTestEnvironment)
+    {
+        // Set test tokens endpoint if using the test environment
+        if (useTestEnvironment)
+        {
+            tokenUrl = testTokensEndpoint;
+        }
+    }
 
 
 
     public String getApiToken(String clientId, String clientSecret) throws Exception
     {
         URL obj = new URL(tokenUrl);
+        log.debug("Starfish tokens URL: {}", tokenUrl);
         HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
 
         // Setup request

--- a/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/callback/SdkObservationCallback.java
+++ b/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/callback/SdkObservationCallback.java
@@ -62,8 +62,8 @@ public class SdkObservationCallback extends SdkCallback {
 
         if (payloadAsStr.length() > 0) {
             log.info("Sending observation to Starfish");
-            StarfishClient starfishClient = new StarfishClient(arguments.getClientId(), arguments.getClientSecret());
-            starfishClient.sendObservation(payloadAsStr, arguments.getDeviceId());
+            StarfishClient starfishClient = new StarfishClient(arguments.getClientId(), arguments.getClientSecret(), arguments.getDeviceId(), arguments.isTestEnv());
+            starfishClient.sendObservation(payloadAsStr);
         }
     }
 

--- a/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/config/OptionsArgumentsWrapper.java
+++ b/SDK/Java CoAP Client/src/main/java/com/ssn/sdk/coapclient/config/OptionsArgumentsWrapper.java
@@ -29,8 +29,8 @@ public class OptionsArgumentsWrapper
     private String confPath = null;
 
     @Option(name = "--clientPort",
-            usage="Port client expects responses on (6000))")
-    private int clientPort = 6000;
+            usage="Port client expects responses on (7000))")
+    private int clientPort = 7000;
 
     @Option(name = "--method",
             usage="CoAP method (GET)")
@@ -41,8 +41,8 @@ public class OptionsArgumentsWrapper
     private String deviceHost = "localhost";
 
     @Option(name = "--devicePort",
-            usage = "Port of the device or server URI (5683)")
-    private int devicePort = 5683;
+            usage = "Port of the device or server URI (4849)")
+    private int devicePort = 4849;
 
     @Option(name = "--devicePath",
             usage = "Sets the path of the target URI ('/')")
@@ -57,8 +57,8 @@ public class OptionsArgumentsWrapper
     private String deviceId = "";
 
     @Option(name = "--proxyHost",
-            usage = "IP address or CNAME of a proxy the request is to be sent to (null)")
-    private String proxyHost = null;
+            usage = "IP address or CNAME of a proxy the request is to be sent to (api.coap-staging.developer.ssni.com)")
+    private String proxyHost = "api.coap-staging.developer.ssni.com";
 
     @Option(name = "--proxyPort",
             usage = "Sets the port of a proxy the request is to be sent to (5683)")
@@ -87,6 +87,10 @@ public class OptionsArgumentsWrapper
     @Option(name = "--clientSecret",
             usage = "Sets the Starfish cleint Secret ('')")
     private String clientSecret = "";
+
+    @Option(name = "--test",
+            usage = "Empty argument that sets endpoints for the TEST network")
+    private boolean testenv = false;
 
     @Option(name = "--help",
             usage = "Prints option help")
@@ -191,6 +195,12 @@ public class OptionsArgumentsWrapper
         {
             clientSecret = soption;
             log.debug("Conf clientSecret: {}", clientSecret);
+        }
+        boption = jo.optBoolean("test");
+        if (boption)
+        {
+            testenv = true;
+            log.debug("Conf test: {}", true);
         }
 
         JSONArray darray = jo.getJSONArray("devices");
@@ -340,6 +350,13 @@ public class OptionsArgumentsWrapper
      */
     public String getClientSecret() {
         return clientSecret;
+    }
+
+    /**
+     * @return <code>true</code> if --test was given as console parameter or <code>false</code> otherwise
+     */
+    public boolean isTestEnv() {
+        return testenv;
     }
 
     /**

--- a/SDK/Java CoAP Client/src/main/resources/log4j.default.xml
+++ b/SDK/Java CoAP Client/src/main/resources/log4j.default.xml
@@ -8,10 +8,6 @@
         </layout>
     </appender>
 
-    <!--<appender name="async" class="org.apache.log4j.AsyncAppender">-->
-        <!--<param name="BufferSize" value="1000000"/>-->
-        <!--<appender-ref ref="console"/>-->
-    <!--</appender>-->
 
     <logger name="com.ssn.sdk.coapclient.config.OptionsArgumentsWrapper">
         <level value="info"/>


### PR DESCRIPTION
Added back support for Starfish Test environment. See the readme for the --test option. Minor code cleanup and refactoring. Improced option defaults for proxy host.