### PR TITLE
Fixed temp sensor type used for testing

### DIFF
--- a/HDK/hdkmshield/README.md
+++ b/HDK/hdkmshield/README.md
@@ -19,9 +19,9 @@ Sensors | Sensor code for the sensors supported by the referenece package
 
 ### Installation Instructions:
 The Sensor API reference package uses CMSIS open source support files, libraries, and ARM MCU abstraction files.
-It is designed to be a stand alone package that can be built with CMake based tool chains.
+It is designed to be a stand-alone package that can be built with CMake based tool chains.
 The code and documentation has been built and tested using the JetBrains CLion IDE.
-Itron supports the use of the CLion IDE in it's Partner Developer Program.
+Itron supports the use of the CLion IDE in its Partner Developer Program.
 
-To build and install the CMSIS based Sensor API package please refer to the instuctions located
+To build and install the CMSIS based Sensor API package please refer to the instructions located
 on the Itron Developer Program Portal at: https://developer.itron.com/content/building-sensor-api-reference-application-clion

--- a/HDK/hdkmshield/mshield.cpp
+++ b/HDK/hdkmshield/mshield.cpp
@@ -79,7 +79,6 @@
 static uint8_t temp_sensor_id;
 static uint8_t echo_sensor_id;
 
-#define LONG_TEMP_SENSOR_TYPE	"bl-snsr-temp"
 
 
 //
@@ -104,7 +103,7 @@ void setup()
     //dlog(LOG_DEBUG, "After sapi_initialize");
 	
 	// Register temp sensor
-	temp_sensor_id = sapi_register_sensor(LONG_TEMP_SENSOR_TYPE, temp_init_sensor, temp_read_sensor, temp_read_cfg, temp_write_cfg, 1, 60);
+	temp_sensor_id = sapi_register_sensor(TEMP_SENSOR_TYPE, temp_init_sensor, temp_read_sensor, temp_read_cfg, temp_write_cfg, 1, 120);
 	
 	// Initialize temp sensor
 	rcode = sapi_init_sensor(temp_sensor_id);


### PR DESCRIPTION
Removed the temp sensor type used for testing. It got checked in by mistake. Fixed typos in the README.md file.